### PR TITLE
Divide total price logic from component

### DIFF
--- a/lib/blocs/subscription_item_bloc.dart
+++ b/lib/blocs/subscription_item_bloc.dart
@@ -6,8 +6,10 @@ import 'package:subsuke/models/subsc.dart';
 
 typedef ItemSinkAdd = Function(List<SubscriptionItem>);
 typedef ItemStream = Stream<List<SubscriptionItem>>;
-typedef ItemStreamTransformer
+typedef ItemTransformer
     = StreamTransformer<List<SubscriptionItem>, List<SubscriptionItem>>;
+typedef ItemSubscription = StreamSubscription<List<SubscriptionItem>>;
+typedef ProratedPrice = Map<PaymentInterval, int>;
 
 class SubscriptionItemBLoC {
   final _selectedIntervals = BehaviorSubject<List<int>>.seeded(<int>[]);
@@ -40,12 +42,106 @@ class SubscriptionItemBLoC {
     return _sortCondition.stream.value;
   }
 
-  final _itemController = BehaviorSubject<List<SubscriptionItem>>();
-  Stream<List<SubscriptionItem>> get itemStream =>
-      _itemController.stream.transform(itemFilter()).transform(itemSort());
+  final _items = BehaviorSubject<List<SubscriptionItem>>();
 
-  ItemStreamTransformer itemFilter() {
-    return ItemStreamTransformer.fromHandlers(
+  final _actual = BehaviorSubject<int>();
+  Stream<int> get actualPriceStream => _actual.stream;
+  int get actualPrice => _actual.stream.value;
+
+  final _total = BehaviorSubject<ProratedPrice>();
+  Stream<ProratedPrice> get proratedPriceStream => _total.stream;
+  ProratedPrice get proratedPrice => _total.stream.value;
+
+  ItemSubscription actualMonthlyPriceListener() {
+    return _items.stream.listen((value) {
+      final n = DateTime.now();
+      final days = new DateTime(n.year, n.month, 0).day;
+
+      int actual = 0;
+      value.forEach((v) {
+        switch (v.interval) {
+          case PaymentInterval.Daily:
+            actual += v.price * days;
+            break;
+          case PaymentInterval.Weekly:
+            actual += v.price * (days ~/ 7);
+            break;
+          case PaymentInterval.Fortnightly:
+            actual += v.price * (days ~/ 14);
+            break;
+          case PaymentInterval.Monthly:
+            actual += v.price;
+            break;
+          case PaymentInterval.Yearly:
+            if (v.next.month == n.month) {
+              actual += v.price;
+            }
+            break;
+        }
+      });
+      _actual.sink.add(actual);
+    });
+  }
+
+  ItemSubscription proratedPriceListener() {
+    return _items.stream.listen((value) {
+      int daily = 0;
+      int weekly = 0;
+      int monthly = 0;
+      int yearly = 0;
+
+      value.forEach(
+        (data) {
+          switch (data.interval) {
+            case PaymentInterval.Daily:
+              final y = data.price * 365;
+              daily += data.price;
+              weekly += data.price * 7;
+              monthly += y ~/ 12;
+              yearly += y;
+              break;
+            case PaymentInterval.Weekly:
+              final y = data.price ~/ 7 * 365;
+              daily += data.price ~/ 7;
+              weekly += data.price;
+              monthly += y ~/ 12;
+              yearly += y;
+              break;
+            case PaymentInterval.Fortnightly:
+              final y = data.price ~/ 14 * 365;
+              daily += data.price ~/ 14;
+              weekly += data.price ~/ 2;
+              monthly += y ~/ 12;
+              yearly += y;
+              break;
+            case PaymentInterval.Monthly:
+              final d = data.price * 12 ~/ 365;
+              daily += d;
+              weekly += d * 7;
+              monthly += data.price;
+              yearly += data.price * 12;
+              break;
+            case PaymentInterval.Yearly:
+              final d = data.price ~/ 365;
+              daily += d;
+              weekly += d * 7;
+              monthly += data.price ~/ 12;
+              yearly += data.price;
+              break;
+          }
+        },
+      );
+      _total.sink.add({
+        PaymentInterval.Daily: daily,
+        PaymentInterval.Weekly: weekly,
+        PaymentInterval.Monthly: monthly,
+        PaymentInterval.Yearly: yearly
+      });
+    });
+  }
+
+  ItemTransformer itemFilter() {
+    return ItemTransformer.fromHandlers(
       handleData: ((data, sink) {
         final selected = _selectedIntervals.value;
         final filtered = data.where((item) {
@@ -59,33 +155,38 @@ class SubscriptionItemBLoC {
     );
   }
 
-  ItemStreamTransformer itemSort() {
-    return StreamTransformer.fromHandlers(handleData: ((data, sink) {
-      final sortCondition = _sortCondition.value;
-      data.sort(((a, b) {
-        switch (sortCondition) {
-          case ItemSortCondition.None:
-            return 1;
-          case ItemSortCondition.PriceASC:
-            return a.price.compareTo(b.price);
-          case ItemSortCondition.PriceDESC:
-            return a.price.compareTo(b.price) * -1;
-          case ItemSortCondition.NextASC:
-            return a.next.compareTo(b.next);
-          case ItemSortCondition.NextDESC:
-            return a.next.compareTo(b.next) * -1;
-        }
-      }));
-      sink.add(data);
-    }));
+  ItemTransformer itemSort() {
+    return StreamTransformer.fromHandlers(
+      handleData: ((data, sink) {
+        final sortCondition = _sortCondition.value;
+        data.sort(((a, b) {
+          switch (sortCondition) {
+            case ItemSortCondition.None:
+              return 1;
+            case ItemSortCondition.PriceASC:
+              return a.price.compareTo(b.price);
+            case ItemSortCondition.PriceDESC:
+              return a.price.compareTo(b.price) * -1;
+            case ItemSortCondition.NextASC:
+              return a.next.compareTo(b.next);
+            case ItemSortCondition.NextDESC:
+              return a.next.compareTo(b.next) * -1;
+          }
+        }));
+        sink.add(data);
+      }),
+    );
   }
 
-  ItemSinkAdd get setSubscriptionItems => _itemController.sink.add;
-  ItemStream get onChangeSubscriptionItems => _itemController.stream;
+  ItemSinkAdd get setSubscriptionItems => _items.sink.add;
+  // ItemStream get onChangeSubscriptionItems => _items.stream;
+  ItemStream get itemStream {
+    return _items.stream.transform(itemFilter()).transform(itemSort());
+  }
 
   getItems() async {
     final items = await DBProvider.instance.getAllSubscriptions();
-    _itemController.sink.add(items.toList());
+    _items.sink.add(items.toList());
   }
 
   create(SubscriptionItem item) {
@@ -105,11 +206,15 @@ class SubscriptionItemBLoC {
 
   SubscriptionItemBLoC() {
     getItems();
+    actualMonthlyPriceListener();
+    proratedPriceListener();
   }
 
   void dispose() {
-    _itemController.close();
+    _items.close();
     _selectedIntervals.close();
     _sortCondition.close();
+    _total.close();
+    _actual.close();
   }
 }

--- a/lib/ui/components/templates/price_carousel.dart
+++ b/lib/ui/components/templates/price_carousel.dart
@@ -2,85 +2,42 @@ import 'package:flutter/material.dart';
 import 'package:subsuke/models/subsc.dart';
 import 'package:subsuke/ui/components/ui_parts/price_card.dart';
 
-class PriceCarousel extends StatelessWidget {
-  final List<SubscriptionItem> items;
-  final int defaultTab;
+class CarouselContent extends StatelessWidget {
+  final List<Widget> children;
+  CarouselContent({required this.children});
 
-  PriceCarousel({required this.items, this.defaultTab = 0});
-
-  List<Widget> childBuilder(BuildContext ctx, List<SubscriptionItem> items) {
-    int daily = 0;
-    int weekly = 0;
-    int monthly = 0;
-    int yearly = 0;
-
-    items.forEach(
-      (item) {
-        switch (item.interval) {
-          case PaymentInterval.Daily:
-            final y = item.price * 365;
-            daily += item.price;
-            weekly += item.price * 7;
-            monthly += y ~/ 12;
-            yearly += y;
-            break;
-          case PaymentInterval.Weekly:
-            final y = item.price ~/ 7 * 365;
-            daily += item.price ~/ 7;
-            weekly += item.price;
-            monthly += y ~/ 12;
-            yearly += y;
-            break;
-          case PaymentInterval.Fortnightly:
-            final y = item.price ~/ 14 * 365;
-            daily += item.price ~/ 14;
-            weekly += item.price ~/ 2;
-            monthly += y ~/ 12;
-            yearly += y;
-            break;
-          case PaymentInterval.Monthly:
-            final d = item.price * 12 ~/ 365;
-            daily += d;
-            weekly += d * 7;
-            monthly += item.price;
-            yearly += item.price * 12;
-            break;
-          case PaymentInterval.Yearly:
-            final d = item.price ~/ 365;
-            daily += d;
-            weekly += d * 7;
-            monthly += item.price ~/ 12;
-            yearly += item.price;
-            break;
-        }
-      },
-    );
-
-    return [
-      PriceCard(daily, PaymentInterval.Daily),
-      PriceCard(weekly, PaymentInterval.Weekly),
-      PriceCard(monthly, PaymentInterval.Monthly),
-      PriceCard(yearly, PaymentInterval.Yearly),
-    ]
-        .map(
-          (w) => Padding(
-            padding: EdgeInsets.all(12),
-            child: Container(
+  @override
+  Widget build(BuildContext context) {
+    return TabBarView(
+      children: children
+          .map(
+            (c) => Padding(
+              padding: EdgeInsets.all(12),
+              child: Container(
                 decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                      color: Theme.of(ctx).cardTheme.shadowColor!,
+                      color: Theme.of(context).cardTheme.shadowColor!,
                       spreadRadius: 0.1,
                       blurRadius: 7.0,
                       offset: Offset(0, 5.0),
                     )
                   ],
                 ),
-                child: w),
-          ),
-        )
-        .toList();
+                child: c,
+              ),
+            ),
+          )
+          .toList(),
+    );
   }
+}
+
+class PriceCarousel extends StatelessWidget {
+  final Map<PaymentInterval, int> prices;
+  final int defaultTab;
+
+  PriceCarousel({required this.prices, this.defaultTab = 0});
 
   @override
   Widget build(BuildContext context) {
@@ -93,9 +50,24 @@ class PriceCarousel extends StatelessWidget {
           children: [
             Expanded(
               flex: 5,
-              child: TabBarView(
-                children: childBuilder(context, items),
-              ),
+              child: CarouselContent(children: [
+                PriceCard(
+                  prices[PaymentInterval.Daily] ?? 0,
+                  PaymentInterval.Daily,
+                ),
+                PriceCard(
+                  prices[PaymentInterval.Weekly] ?? 0,
+                  PaymentInterval.Weekly,
+                ),
+                PriceCard(
+                  prices[PaymentInterval.Monthly] ?? 0,
+                  PaymentInterval.Monthly,
+                ),
+                PriceCard(
+                  prices[PaymentInterval.Yearly] ?? 0,
+                  PaymentInterval.Yearly,
+                ),
+              ]),
             ),
             Expanded(
               flex: 1,

--- a/lib/ui/pages/analytics.dart
+++ b/lib/ui/pages/analytics.dart
@@ -24,7 +24,7 @@ class AnalyticsPage extends StatelessWidget {
                   case ConnectionState.waiting:
                     return Center(child: CircularProgressIndicator());
                   default:
-                    return PriceCarousel(items: ss.data!);
+                    return PriceCarousel(prices: bloc.proratedPrice);
                 }
               },
             ),

--- a/lib/ui/pages/list/list.android.dart
+++ b/lib/ui/pages/list/list.android.dart
@@ -50,7 +50,7 @@ class ListPageAndroid extends StatelessWidget {
                   SliverGrid.count(
                     childAspectRatio: 1.6,
                     crossAxisCount: 1,
-                    children: [PriceCarousel(items: ss.data ?? [])],
+                    children: [PriceCarousel(prices: bloc.proratedPrice)],
                   ),
                   SliverFixedExtentList(
                     itemExtent: 180,

--- a/lib/ui/pages/list/list.ios.dart
+++ b/lib/ui/pages/list/list.ios.dart
@@ -58,7 +58,7 @@ class ListPageIOS extends StatelessWidget {
                     crossAxisCount: 1,
                     children: [
                       PriceCarousel(
-                        items: ss.data ?? [],
+                        prices: bloc.proratedPrice,
                         defaultTab: pref.getDefaultCarousel(),
                       )
                     ],


### PR DESCRIPTION
## Description

- Remove total price logic from PriceCarousel components.
- Add total price logic to SubscriptionBLoC.

Prorated price and actual price (monthly price only) are available.

Fixes #41 (issue)